### PR TITLE
Fix typo in config set command

### DIFF
--- a/labs/intro/python/lab-02/README.md
+++ b/labs/intro/python/lab-02/README.md
@@ -40,7 +40,7 @@ error: Missing required configuration variable 'stack-1:required_value'
 Set the configuration option that is missing:
 
 ```bash
-pulumi config set required_value = "i-am-required"
+pulumi config set required_value "i-am-required"
 ```
 
 Re-run `pulumi up` and see that your pulumi program runs successfully, but there's no output.


### PR DESCRIPTION
If you try running the command as specified you will get the following error:
`error: accepts between 1 and 2 arg(s), received 3`