### PR TITLE
Fix example so ports is passed a list

### DIFF
--- a/labs/intro/python/lab-03/README.md
+++ b/labs/intro/python/lab-03/README.md
@@ -107,10 +107,10 @@ image = Image("my-cool-image",
 
 container = Container('my-running-image',
                       image=image.image_name,
-                      ports=ContainerPortArgs(
+                      ports=[ContainerPortArgs(
                           internal=8000,
                           external=8000,
-                      ))
+                      )])
 
 pulumi.export("container_id", container.id)
 ```


### PR DESCRIPTION
If you try to run the code prior to this change then you end up with the following error:

`error: docker:index/container:Container resource 'my-running-image' has a problem: ports: should be a list`

For a non python dev this was actually quite confusing as I wasn't clear if it was python generating this error or one of the APIs that it was calling. The "see below for details" in the API docs also wasn't too helpful: https://www.pulumi.com/docs/reference/pkg/docker/container/#ports_python