### PR TITLE
Update step 4

### DIFF
--- a/labs/aws/in-person/typescript/lab-02/code/step4.ts
+++ b/labs/aws/in-person/typescript/lab-02/code/step4.ts
@@ -1,7 +1,7 @@
 import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
 
-const ami = aws.getAmi({
+const ami = aws.ec2.getAmi({
     filters: [{ name: "name", values: ["amzn-ami-hvm-*-x86_64-ebs"] }],
     owners: [ "137112412989" ],
     mostRecent: true,

--- a/labs/aws/in-person/typescript/lab-02/code/step4.ts
+++ b/labs/aws/in-person/typescript/lab-02/code/step4.ts
@@ -21,21 +21,24 @@ const listener = alb.createListener("web-listener", { port: 80 });
 
 export const ips: any[] = [];
 export const hostnames: any[] = [];
-for (const az of aws.getAvailabilityZones().names) {
-    const server = new aws.ec2.Instance(`web-server-${az}`, {
-        instanceType: "t2.micro",
-        securityGroups: alb.securityGroups.map(sg => sg.securityGroup.name),
-        ami: ami,
-        availabilityZone: az,
-        userData: "#!/bin/bash\n"+
-            `echo 'Hello, World -- from ${az}!' > index.html\n` +
-            "nohup python -m SimpleHTTPServer 80 &",
-        tags: { "Name": "web-server" },
-    });
-    ips.push(server.publicIp);
-    hostnames.push(server.publicDns);
 
-    alb.attachTarget(`web-target-${az}`, server);
-}
+const az = aws.getAvailabilityZones().then(x => {
+    for (const azName of x.names) {
+        const server = new aws.ec2.Instance(`web-server-${azName}`, {
+            instanceType: "t2.micro",
+            securityGroups: alb.securityGroups.map(sg => sg.securityGroup.name),
+            ami: ami,
+            availabilityZone: azName,
+            userData: "#!/bin/bash\n"+
+                `echo 'Hello, World -- from ${azName}!' > index.html\n` +
+                "nohup python -m SimpleHTTPServer 80 &",
+            tags: { "Name": "web-server" },
+        });
+        ips.push(server.publicIp);
+        hostnames.push(server.publicDns);
+    
+        alb.attachTarget(`web-target-${azName}`, server);
+    }
+});
 
 export const url = listener.endpoint.hostname;


### PR DESCRIPTION
We return a promise when getting availablity zones now. Since we don't support top level await (yet), we need to create the instances in the `then()` method.

Not using the output method so we don't have to use apply and therefore the instances show up in the preview